### PR TITLE
DPPA-1539 Unable to generate MIBItiff if any of the channels contain gamma in its name

### DIFF
--- a/mibidata/tests/test_tiff.py
+++ b/mibidata/tests/test_tiff.py
@@ -25,7 +25,7 @@ LABEL = (img_as_ubyte(transform.rotate(
 CHANNELS = ((1, 'Target1'), (2, 'Target2'), (3, 'Target3'),
             (4, 'Target4'), (5, 'Target5'))
 CHANNELS_NON_ASCII = ((1, 'Targetµ'), (2, 'Targetβ'), (3, 'Targetγ'),
-            (4, 'Targetπ'), (5, 'Targetτ'))
+                      (4, 'Targetπ'), (5, 'Targetτ'))
 METADATA = {
     'run': '20180703_1234_test', 'date': '2017-09-16T15:26:00',
     'coordinates': (12345, -67890), 'size': 500., 'slide': '857',

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -165,7 +165,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
                     'channel.target': image.targets[i],
                 })
                 page_name = (
-                    285, 's', 0, '{} ({})'.format(image.targets[i],
+                    285, 's', 0, '{} ({})'.format(image.targets[i].encode(),
                                                   image.masses[i])
                 )
                 min_value = (340, range_dtype, 1, ranges[i][0])

--- a/mibidata/tiff.py
+++ b/mibidata/tiff.py
@@ -212,7 +212,7 @@ def write(filename, image, sed=None, optical=None, ranges=None,
                 'channel.target': image.targets[i],
             })
             page_name = (285, 's', 0, '{} ({})'.format(
-                image.targets[i], image.masses[i]))
+                image.targets[i].encode(), image.masses[i]))
             min_value = (340, range_dtype, 1, ranges[i][0])
             max_value = (341, range_dtype, 1, ranges[i][1])
             page_tags = coordinates + [page_name, min_value, max_value]


### PR DESCRIPTION
Happens only in VMs used for research-services.

Use conda list to compare instrument vs VM library versions.

For reproducing the error, use the latest mibilib and call the following using the tiff file below:

tiff.write('/Users/murat/Downloads/test.tiff', tiff.read('/Users/murat/Downloads/20210613_6247_Run-3864_FOV2_ROI1.tiff'))

Using utf-8 instead of ascii in tifffile.py L1902 works, but this is not a good solution since it requires a custom change to the underlying library.

The solution proposed here converts the page tag into bytes string so that tifffile.py does not try to convert it to ascii.