### PR TITLE
Changing requests to minimum version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
       - run:
           name: Run tests
           command: |
+            sudo apt-get update
             sudo apt install default-jre
             ~/miniconda/envs/mibilib/bin/coverage run -m py.test mibitracker mibidata scripts
             ~/miniconda/envs/mibilib/bin/coverage html -i --omit=*/tests/*

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - pillow==8.2.0
   - pylint==2.3.1
   - pytest==5.2.0
-  - requests==2.20.1
+  - requests>=2.20.1
   - scikit-image==0.18.0
   - scikit-learn==0.23.2
   - setuptools==40.4.0


### PR DESCRIPTION
Changing to  `requests>=2.20.1` in `environment.yml` file to allow dependency compatibility with icb-client repo